### PR TITLE
🚨 Add missing GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Fixes Issue #6: Missing GitHub Skills Activity

This PR adds the missing **GitHub Skills** activity that was announced by the principal but wasn't available for student registration.

### 📋 Changes Made

- ✅ Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- ✅ Included description mentioning GitHub Certifications program and college application benefits
- ✅ Set schedule for Mondays and Wednesdays, 3:30 PM - 4:30 PM
- ✅ Set capacity for 25 students (reasonable for programming-focused activity)
- ✅ Started with empty participants list (ready for new registrations)

### 🚀 Impact

- **Immediate:** Students can now register for the GitHub Skills activity before the end-of-week deadline
- **Educational:** Supports the school's GitHub Certifications program partnership
- **Future:** Helps students with college applications through practical coding skills

### 🔍 Testing

- ✅ Application imports successfully
- ✅ GitHub Skills activity is properly added to activities dictionary
- ✅ Follows existing code patterns and structure

**Ready for review and merge!** 🎉

Closes #6